### PR TITLE
Update tutorial.py

### DIFF
--- a/tutorial.py
+++ b/tutorial.py
@@ -2,7 +2,8 @@ from cassandra.cluster import Cluster
 from cassandra.auth import PlainTextAuthProvider
 from langchain.memory import CassandraChatMessageHistory, ConversationBufferMemory
 from langchain.llms import OpenAI
-from langchain import LLMChain, PromptTemplate
+from langchain.chains import LLMChain
+from langchain.prompts import PromptTemplate
 import json
 
 cloud_config= {


### PR DESCRIPTION
Fix to UserWarning: Importing LLMChain from langchain root module is no longer supported. UserWarning: Importing PromptTemplate from langchain root module is no longer supported.